### PR TITLE
Add data source print string method to FTBasicItem. This enable to ov…

### DIFF
--- a/repository/SpecUIAddOns.package/FTBasicItem.extension/instance/dsPrintString.st
+++ b/repository/SpecUIAddOns.package/FTBasicItem.extension/instance/dsPrintString.st
@@ -1,0 +1,5 @@
+*SpecUIAddOns
+dsPrintString 
+	" Private - Answer a <String> used as representation in the data source "
+	
+	^ data dsPrintString


### PR DESCRIPTION
…erride the use of #name for printing items in FastTable